### PR TITLE
Visibility flag for freeimage to enable linking different jpeg versions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -714,7 +714,7 @@ set(FREEIMAGE_SOURCES
     "${OF_ROOT_DIR}/src/freeimage/Source/OpenEXR/IexMath/IexMathFpu.cpp"
 )
 
-set_source_files_properties(${FREEIMAGE_SOURCES} PROPERTIES COMPILE_FLAGS -w)
+set_source_files_properties(${FREEIMAGE_SOURCES} PROPERTIES COMPILE_FLAGS "-w -fvisibility=hidden")
 
 set(KISSFFT_SOURCES
     "${OF_ROOT_DIR}/src/kissfft/tools/kiss_fftr.c"


### PR DESCRIPTION
This enables linking of other libraries that are built against different versions of libjpeg or libjpeg-turbo.
GCC exports symbols visible by default.
Setting symbol visibility to hidden avoids conflicts with libraries built against, for example, system libraries.

Actually, it is set in the make file of the freeimage subdir, which is not used by the cmake build.
https://github.com/ofnode/of/blob/master/src/freeimage/Makefile.gnu#L18

