### PR TITLE
Check if addon has include path before include

### DIFF
--- a/openFrameworks.cmake
+++ b/openFrameworks.cmake
@@ -1111,7 +1111,9 @@ function(ofxaddon OFXADDON)
           endif()
         endforeach()
 
-        include_directories("${OFXLIBHEADER_PATHS}")
+        if (NOT "${OFXLIBHEADER_PATHS}" STREQUAL "")
+            include_directories("${OFXLIBHEADER_PATHS}")
+        endif()
         include_directories("${OFXADDON_DIR}/src")
         include_directories("${OFXADDON_DIR}/libs")
 


### PR DESCRIPTION
Some addons ship with all their headers in the src directory, thus they do not have an include directory (example: ofxMSAOpenCL).
Executing the include_directories() command with an empty string results in an error.
This checks if any include folder was found (if the OFXLIBHEADER_PATHS variable is not an empty string) before trying to include the directory.